### PR TITLE
JVM Options Documentation in Developer Guide

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -20,8 +20,15 @@
     - Work directories: 
       - ```sudo mkdir -p /var/run/kubernetes; sudo chown `whoami`:`whoami` /var/run/kubernetes```
     - Etcd: 
-      - ignite-etcd: `ignite-etcd/build/install/ignite-etcd/bin/ignite-etcd -Djava.net.preferIPv4Stack=true --server-port=2379 --ignite-config=docs/ignite-server-dev-local.xml`
-      - OR native etcd: `$K8S_REPO/third_party/etcd/etcd --listen-client-urls=http://127.0.0.1:2479 --advertise-client-urls=http://127.0.0.1:2479 --data-dir=/tmp/default.etcd` 
+      - ignite-etcd:
+        ```shell script
+        export IGNITE_ETCD_OPTS=-Djava.xml.net=preferIPv4Stack
+        ignite-etcd/build/install/ignite-etcd/bin/ignite-etcd --server-port=2379 --ignite-config=docs/ignite-server-dev-local.xml
+        ```
+      - OR native etcd:
+        ```shell script
+        $K8S_REPO/third_party/etcd/etcd --listen-client-urls=http://127.0.0.1:2479 --advertise-client-urls=http://127.0.0.1:2479 --data-dir=/tmp/default.etcd
+        ```
     - API Server: `$K8S_REPO/_output/bin/kube-apiserver --etcd-servers=http://127.0.0.1:2379 --service-cluster-ip-range=127.0.0.1/24 --storage-media-type=application/json`
     - Scheduler: `$K8S_REPO/_output/bin/kube-scheduler --master=http://127.0.0.1:8080`
     - Controller Manager: `$K8S_REPO/_output/bin/kube-controller-manager --master=http://127.0.0.1:8080 --service-account-private-key-file=/var/run/kubernetes/apiserver.key`


### PR DESCRIPTION
Closes #69 JVM Options Documentation in Developer Guide docs/dev-guide.md

The existing implementation already supported JVM argument passing via environment variable IGNITE_ETCD_OPTS, this is purely a documentation fix to make use of it in the Developer Guide.
