### PR TITLE
Initial benchmark commits

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -154,42 +154,42 @@ With the two environments variables, you should be able to run all etcdctl or be
 # Example .profile 
 Below is an example of the env variables and settings added to the ubuntu .profile file (for the tests ran in GCE):
 
-/# Set Java Home and ignite optimized JVM settings
+\# Set Java Home and ignite optimized JVM settings
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"
 
-/# Set GO environment variables and update PATH
+\# Set GO environment variables and update PATH
 export GOPATH=$HOME/dev/go
 export PATH=$PATH:$GOPATH/bin
 export PATH=$PATH:/usr/local/go/bin
 
-/# Set ignite HOME and update PATH
+\# Set ignite HOME and update PATH
 export IGNITE_HOME=${HOME}/dev/ignite
 export PATH=$PATH:${IGNITE_HOME}/bin
 
-/# Set ignite-etcd HOME and update PATH
+\# Set ignite-etcd HOME and update PATH
 export IGNITE_ETCD_CONFIG=${HOME}/dev/igk8s-configs
 export IGNITE_ETCD_HOME=${HOME}/dev/igk8s/ignite-etcd/build/install/ignite-etcd
 export PATH=$PATH:${IGNITE_ETCD_HOME}/bin
 
-/# Set Internal (Static) Server IPs
+\# Set Internal (Static) Server IPs
 export SERVER_1_IP=10.162.0.2
 export SERVER_2_IP=10.162.0.3
 export SERVER_3_IP=10.162.0.11
 export SERVER_4_IP=10.162.0.9
 export SERVER_5_IP=10.162.0.10
 
-/# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables
+\# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables
 export ETCDCTL_API=3
 export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd
 
-/# Set these only when starting up a new etcd cluster for the first time!
-/# After the cluster is up and running, comment out these settings (and run source .profile)
-#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
-#export ETCD_INITIAL_CLUSTER_STATE=new
-#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.
+\# Set these only when starting up a new etcd cluster for the first time!
+\# After the cluster is up and running, comment out these settings (and run source .profile)
+\#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
+\#export ETCD_INITIAL_CLUSTER_STATE=new
+\#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.
 
-/# Set etcd endpoints (for benchmark and client apps)
+\# Set etcd endpoints (for benchmark and client apps)
 export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379
 export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -96,8 +96,10 @@ Starting etcd clusters is generally very easy (per on-line documentation).  But 
 #export ETCD_INITIAL_CLUSTER_STATE=new  
 #export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
 
-Then to start an etcd cluster using the command below on each etcd server (in a script or terminal session):  
-(The --name parameter is optional.  See the full .profile example below to see how the INITIIAL CLUSTER and SERVER_IP variables are set and automatically added)  
+Then to start an etcd cluster, run a etcd start command (like the one below) for each etcd server node (in a script or terminal session):  
+The --name parameter is important and must be the same as in the .profile env variables.  
+See the full **Example .profile** below to see how the INITIIAL CLUSTER and SERVER_IP variables should be set). 
+
 etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \  
   --listen-peer-urls http://${SERVER_1_IP}:2380 \  
   --listen-client-urls http://${SERVER_1_IP}:2379,http://127.0.0.1:2379 \  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@
 The intended result is 5 servers: 3 server nodes, 1 client node (used only in the ignite-etcd configuration), and 1 benchmark node.  
 The run-time difference between the etcd and ignite-etcd configuration is that the benchmark app/node queries the 3 server-nodes:
 - directly (for the standard etcd configuration) and the igntite-etcd client/shim node is not used.  
-- indirectly (via the ignite-etcd client/node) for the ignite-etcd configuration.  
+- indirectly (via the ignite-etcd client/shim node) for the ignite-etcd configuration.  
 
 Each of the nodes should contain in $HOME:  
 (1) At most two startup (or benchmark) scripts copied from the repo/branch folder 'home' to the Unbuntu $HOME folder.  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -9,9 +9,11 @@ The 3 server nodes and the 1 client node should contain in $HOME:
     For server node 1: start-etcd1.sh and start-ignite.sh  
     For server node 2: start-etcd2.sh and start-ignite.sh  
     For server node 3: start-etcd3.sh and start-ignite.sh  
-    For the client/shim node: start-ignite-etcd-shim.sh  
+    For the client/shim node: start-ignite-etcd-shim.sh 
+    
 (2) A 'dev' folder that should contain the following sub-folders:  
-    etcd  go  igk8s  igk8s-config  ignite  
+    etcd  go  igk8s  igk8s-config  ignite 
+    
 (3) The benchmark node should contain one benchmark folder under $HOME.
 
 Please contact me for help/questions until I can get this branch in a fully clonable state.
@@ -39,13 +41,13 @@ So you can copy all the .profile extensions at once, or build them step by step,
 
 To install Java 8 on Ubunutu server/machine:
 -------------------------------------------
-sudo apt update
-sudo apt install openjdk-8-jdk openjdk-8-jre
+sudo apt update  
+sudo apt install openjdk-8-jdk openjdk-8-jre  
 java -version
 
-add to ~/.profile:
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"
+add to ~/.profile:  
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64  
+export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"  
 
 $ source .profile
 
@@ -56,33 +58,31 @@ To install Go on Ubuntu server/machine:
 
 wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 
-add to ~/.profile:
+add to ~/.profile:  
 export PATH=$PATH:/usr/local/go/bin
 
-optionally add to ~/.profile a path for Go projects such as:
-
-export GOPATH=$HOME/dev/go
-
+optionally add to ~/.profile a path for Go projects such as:  
+export GOPATH=$HOME/dev/go  
 export PATH=$PATH:$GOPATH/bin
 
-$ source .profile
-$ go version
+$ source .profile  
+$ go version  
 
 To install etcd
 ----------------
-(1) Open in a browser the desired release link, e.g. for 3.5: https://github.com/etcd-io/etcd/releases/tag/v3.5.0
-(2) Copy the install script (displayed on the etcd webpage) directly into your ubuntu terminal session (maybe they will change that someday :) 
-(3) The copied script will download etcd into folder: /tmp/etcd-download-test
-(4) copy the three etcd binaries (etcd, etcdctl, etcdutl) to /usr/local/bin:
-    sudo cp /tmp/etcd-download-test/etcd /usr/local/bin/
-    sudo cp /tmp/etcd-download-test/etcdctl /usr/local/bin/
-    sudo cp /tmp/etcd-download-test/etcdutl /usr/local/bin/
-(5) verify with:  etcd -version
-      etcd Version: 3.5.0
-      Git SHA: 946a5a6f2
-      Go Version: go1.16.3
-      Go OS/Arch: linux/amd64
-(6) Move or delete the /tmp/ectcd-download-test folder (and its contents) as desired (or just leave it as is).  No other etcd files are not needed for this project.
+(1) Open in a browser the desired release link, e.g. for 3.5: https://github.com/etcd-io/etcd/releases/tag/v3.5.0  
+(2) Copy the install script (displayed on the etcd webpage) directly into your ubuntu terminal session (maybe they will change that someday :)  
+(3) The copied script will download etcd into folder: /tmp/etcd-download-test  
+(4) copy the three etcd binaries (etcd, etcdctl, etcdutl) to /usr/local/bin:  
+    sudo cp /tmp/etcd-download-test/etcd /usr/local/bin/  
+    sudo cp /tmp/etcd-download-test/etcdctl /usr/local/bin/  
+    sudo cp /tmp/etcd-download-test/etcdutl /usr/local/bin/  
+(5) verify with:  etcd -version  
+      etcd Version: 3.5.0  
+      Git SHA: 946a5a6f2  
+      Go Version: go1.16.3  
+      Go OS/Arch: linux/amd64  
+(6) Move or delete the /tmp/ectcd-download-test folder (and its contents) as desired (or just leave it as is).  No other etcd files are not needed for this project.  
 
 VERY IMPORTANT: FOR THE FIRST TIME YOU START UP A MULTI_NODE ETCD CLUSTER
 -------------------------------------------------------------------------

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -86,55 +86,54 @@ To install etcd
 
 VERY IMPORTANT: FOR THE FIRST TIME YOU START UP A MULTI_NODE ETCD CLUSTER
 -------------------------------------------------------------------------
-Starting etcd clusters is generally very easy (per on-line documentation).  But restarting, resetting, clearing etcd clusters, once started can be very confusing until some basics are understood.
-(1) Every time you start a "NEW" cluster (not restart an already existing cluster), you must provide a new unqiue token ID (see the .profile example below).
-(2) If you want to start over with a new cluster, you should delete the etcd db directory (called default.etcd unless you rename it) on all servers, AND change the new cluster token ID (in the .profile example below) -- this is very important or very strange things start to happen.
-(3) There are probably better ways to do this, but they require a good deal more understanding of etcd (refer to the documentation if you need this understanding).
-(4) Basically, understand and set these environment variables (any time you start a new cluster), and uncomment them after the cluster is fully up (yes, wierd).
-#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
-#export ETCD_INITIAL_CLUSTER_STATE=new
-#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.
+Starting etcd clusters is generally very easy (per on-line documentation).  But restarting, resetting, clearing etcd clusters, once started can be very confusing until some basics are understood.  
+(1) Every time you start a "NEW" cluster (not restart an already existing cluster), you must provide a new unqiue token ID (see the .profile example below).  
+(2) If you want to start over with a new cluster, you should delete the etcd db directory (called default.etcd unless you rename it) on all servers, AND change the new cluster token ID (in the .profile example below) -- this is very important or very strange things start to happen.  
+(3) There are probably better ways to do this, but they require a good deal more understanding of etcd (refer to the documentation if you need this understanding).  
+(4) Basically, understand and set these environment variables (any time you start a new cluster), and uncomment them after the cluster is fully up (yes, wierd).  
+#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
+#export ETCD_INITIAL_CLUSTER_STATE=new  
+#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
 
-Then to start an etcd cluster using the command below on each etcd server (in a script or terminal session):
-(The --name parameter is optional.  See the full .profile example below to see how the INITIIAL CLUSTER and SERVER_IP variables are set and automatically added)
-etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \
-  --listen-peer-urls http://${SERVER_1_IP}:2380 \
-  --listen-client-urls http://${SERVER_1_IP}:2379,http://127.0.0.1:2379 \
-  --advertise-client-urls http://${SERVER_1_IP}:2379 \
-
+Then to start an etcd cluster using the command below on each etcd server (in a script or terminal session):  
+(The --name parameter is optional.  See the full .profile example below to see how the INITIIAL CLUSTER and SERVER_IP variables are set and automatically added)  
+etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \  
+  --listen-peer-urls http://${SERVER_1_IP}:2380 \  
+  --listen-client-urls http://${SERVER_1_IP}:2379,http://127.0.0.1:2379 \  
+  --advertise-client-urls http://${SERVER_1_IP}:2379
 
 To install benchmark: (note the /v3/ below -- make sure the benchmark is for your desired version)
 --------------------------------------------------------------------------------------------------
 
-$ go get go.etcd.io/etcd/v3/tools/benchmark
+$ go get go.etcd.io/etcd/v3/tools/benchmark  
 $ benchmark --help
 
 For the ignite-etc installs, create a home directory, such as dev:
 ------------------------------------------------------------------
-cd $HOME
+cd $HOME  
 mkdir dev
 
 
 To install ignite v2.10.0 (binaries only)
 -----------------------------------------
-cd $HOME/dev
+cd $HOME/dev  
 wget https://archive.apache.org/dist/ignite/2.10.0/apache-ignite-2.10.0-bin.zip
 
-If necessary (install unzip)
-sudo apt-get install unzip
-unzip apache-ignite-2.10.0-bin.zip
+If necessary (install unzip)  
+sudo apt-get install unzip  
+unzip apache-ignite-2.10.0-bin.zip  
 
-mv apache-ignite-2.10.0-bin ignite  (simplify name to ignite)
-rm apache-ignite-2.10.0-bin.zip (delete the .zip file if you want to).
+mv apache-ignite-2.10.0-bin ignite  (simplify name to ignite)  
+rm apache-ignite-2.10.0-bin.zip (delete the .zip file if you want to).  
 
 To install and build ignite-in-k8s
 -----------------------------------
-(1) Make sure you are in the 'dev' directory (or the installation folder of choice)
-(2) $ git clone https://github.com/gridgain-solutions/ignite-in-k8s.git
-(3) optionally rename folder to shorter name like: igk8s
-    This project generates a really long path, that can exceed limits on Windows, but is probably not a problem on Linux.
-(4) cd igk8s/ignite-etcd
-(5) ./gradlew installDist (to build the project)
+(1) Make sure you are in the 'dev' directory (or the installation folder of choice)  
+(2) $ git clone https://github.com/gridgain-solutions/ignite-in-k8s.git  
+(3) optionally rename folder to shorter name like: igk8s  
+    This project generates a really long path, that can exceed limits on Windows, but is probably not a problem on Linux.  
+(4) cd igk8s/ignite-etcd  
+(5) ./gradlew installDist (to build the project)  
 
 
 Setting up ETCD Endpoints (to use in etcdcl and benchmark commands)
@@ -143,10 +142,10 @@ All etcdctl and benchmark commands are issused to the same listening port (2379)
 For etcd -- this will be a list of (n) etcd servers.  For ignite-etcd, it may be a single etcd-shim server.  See examples below:
 
 # Set etcd endpoints (for benchmark and client apps)
-export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379
+export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379  
 export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379
 
-Then in etcdctl commands, add the --endpoints=$ETCD_ENDPOINTS  (or IGNITE_ETCD_ENDPOINTS) to the etcdctl command you want to invoke.  (note the = sign).
+Then in etcdctl commands, add the --endpoints=$ETCD_ENDPOINTS  (or IGNITE_ETCD_ENDPOINTS) to the etcdctl command you want to invoke.  (note the = sign).  
 For the benchmark program, omit the '=', so add --endpoints $ETCD_ENDPOINTS  to the benchmark command.
 
 With the two environments variables, you should be able to run all etcdctl or benchmark commands for either etcd or ignite-etcd.  But of course you can only have one test configuration active at a time (if you are using the same machines).  As both etcd and ignite_etcd have to listen on the same port 2379.
@@ -154,46 +153,41 @@ With the two environments variables, you should be able to run all etcdctl or be
 # Example .profile 
 Below is an example of the env variables and settings added to the ubuntu .profile file (for the tests ran in GCE):
 
-\# Set Java Home and ignite optimized JVM settings
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"
+\# Set Java Home and ignite optimized JVM settings  
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64  
+export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"  
 
-\# Set GO environment variables and update PATH
-export GOPATH=$HOME/dev/go
-export PATH=$PATH:$GOPATH/bin
-export PATH=$PATH:/usr/local/go/bin
+\# Set GO environment variables and update PATH  
+export GOPATH=$HOME/dev/go  
+export PATH=$PATH:$GOPATH/bin  
+export PATH=$PATH:/usr/local/go/bin  
 
-\# Set ignite HOME and update PATH
-export IGNITE_HOME=${HOME}/dev/ignite
-export PATH=$PATH:${IGNITE_HOME}/bin
+\# Set ignite HOME and update PATH  
+export IGNITE_HOME=${HOME}/dev/ignite  
+export PATH=$PATH:${IGNITE_HOME}/bin  
 
-\# Set ignite-etcd HOME and update PATH
-export IGNITE_ETCD_CONFIG=${HOME}/dev/igk8s-configs
-export IGNITE_ETCD_HOME=${HOME}/dev/igk8s/ignite-etcd/build/install/ignite-etcd
-export PATH=$PATH:${IGNITE_ETCD_HOME}/bin
+\# Set ignite-etcd HOME and update PATH  
+export IGNITE_ETCD_CONFIG=${HOME}/dev/igk8s-configs  
+export IGNITE_ETCD_HOME=${HOME}/dev/igk8s/ignite-etcd/build/install/ignite-etcd  
+export PATH=$PATH:${IGNITE_ETCD_HOME}/bin  
 
-\# Set Internal (Static) Server IPs
-export SERVER_1_IP=10.162.0.2
-export SERVER_2_IP=10.162.0.3
-export SERVER_3_IP=10.162.0.11
-export SERVER_4_IP=10.162.0.9
-export SERVER_5_IP=10.162.0.10
+\# Set Internal (Static) Server IPs  
+export SERVER_1_IP=10.162.0.2  
+export SERVER_2_IP=10.162.0.3  
+export SERVER_3_IP=10.162.0.11  
+export SERVER_4_IP=10.162.0.9  
+export SERVER_5_IP=10.162.0.10  
 
-\# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables
-export ETCDCTL_API=3
+\# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables  
+export ETCDCTL_API=3  
 export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd
 
-\# Set these only when starting up a new etcd cluster for the first time!
-\# After the cluster is up and running, comment out these settings (and run source .profile)
-\#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
-\#export ETCD_INITIAL_CLUSTER_STATE=new
-\#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.
+\# Set these only when starting up a new etcd cluster for the first time!  
+\# After the cluster is up and running, comment out these settings (and run source .profile)  
+\#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
+\#export ETCD_INITIAL_CLUSTER_STATE=new  
+\#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
 
-\# Set etcd endpoints (for benchmark and client apps)
-export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379
+\# Set etcd endpoints (for benchmark and client apps)  
+export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379  
 export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379
-
-
-
-
- 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -15,8 +15,12 @@ Each of the nodes should contain in $HOME:
  - *For the ignite client/shim node:* start-ignite-etcd-shim.sh
  - *For the benchmark node:* etcd-bm-write-all.sh and ignite-etcd-bm-write-all.sh
     
-(2) A 'dev' folder that should contain the following sub-folders:  
-    etcd  go  igk8s  igk8s-config  ignite 
+(2) A 'dev' folder that should contain the following sub-folders:
+- etcd
+- go
+- igk8s
+- igk8s-config
+- ignite 
     
 (3) The benchmark node (just for consistency) can have the same setup above, but much of it will not be used.  Instead, it will have one addition, the benchmark Go app. The benchmark installation instructions herein will install the benchmark app into GoPath and the app itself into $HOME/dev/go/bin.  It is runnable from any locaton on the server.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,5 @@
 # benchmark
-*Temporary Disclaimer:*  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.
+*Temporary Disclaimer:*  This branch is complete in content, and the instructions herein are accurate, but this not branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node architecture. If futher developed, it should be converted into a Docker containers or some other more suitable state for multi-node deployment.
 
 The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -151,45 +151,45 @@ For the benchmark program, omit the '=', so add --endpoints $ETCD_ENDPOINTS  to 
 
 With the two environments variables, you should be able to run all etcdctl or benchmark commands for either etcd or ignite-etcd.  But of course you can only have one test configuration active at a time (if you are using the same machines).  As both etcd and ignite_etcd have to listen on the same port 2379.
 
-Example .profile 
+# Example .profile 
 Below is an example of the env variables and settings added to the ubuntu .profile file (for the tests ran in GCE):
 
-# Set Java Home and ignite optimized JVM settings
+/# Set Java Home and ignite optimized JVM settings
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"
 
-# Set GO environment variables and update PATH
+/# Set GO environment variables and update PATH
 export GOPATH=$HOME/dev/go
 export PATH=$PATH:$GOPATH/bin
 export PATH=$PATH:/usr/local/go/bin
 
-# Set ignite HOME and update PATH
+/# Set ignite HOME and update PATH
 export IGNITE_HOME=${HOME}/dev/ignite
 export PATH=$PATH:${IGNITE_HOME}/bin
 
-# Set ignite-etcd HOME and update PATH
+/# Set ignite-etcd HOME and update PATH
 export IGNITE_ETCD_CONFIG=${HOME}/dev/igk8s-configs
 export IGNITE_ETCD_HOME=${HOME}/dev/igk8s/ignite-etcd/build/install/ignite-etcd
 export PATH=$PATH:${IGNITE_ETCD_HOME}/bin
 
-# Set Internal (Static) Server IPs
+/# Set Internal (Static) Server IPs
 export SERVER_1_IP=10.162.0.2
 export SERVER_2_IP=10.162.0.3
 export SERVER_3_IP=10.162.0.11
 export SERVER_4_IP=10.162.0.9
 export SERVER_5_IP=10.162.0.10
 
-# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables
+/# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables
 export ETCDCTL_API=3
 export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd
 
-# Set these only when starting up a new etcd cluster for the first time!
-# After the cluster is up and running, comment out these settings (and run source .profile)
+/# Set these only when starting up a new etcd cluster for the first time!
+/# After the cluster is up and running, comment out these settings (and run source .profile)
 #export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
 #export ETCD_INITIAL_CLUSTER_STATE=new
 #export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.
 
-# Set etcd endpoints (for benchmark and client apps)
+/# Set etcd endpoints (for benchmark and client apps)
 export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379
 export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -33,7 +33,7 @@ $ source .profile
 
 To install Go on Ubuntu server/machine:
 --------------------------------------
-(besure to edit the Go version you want, e.g. 16.8 below)
+*Be sure to edit the Go version you want, e.g. 16.8 below*
 wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 
 add to ~/.profile:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -34,12 +34,12 @@ on Ubuntu vms, for either standard etcd or custom ignite-etcd configurations.
 The folders/files herein are scripted for Unbuntu 20.0.4 and are organized into the folders assumed by the current configuration scripts.
 However, these configuration files can be easily changed for alternative Linux distros and/or other desired build configurations.
 
-Once fully configured, the etcd benchmarks can be run for only one configuration at a time (either for etcd or for ignite-ectd).
+Once fully configured, the etcd benchmarks can be run for only one configuration at any given time (either for etcd or for ignite-ectd).
 
 The benchmark folders are:
 
 - [home folder](README.md): startup and benchmark scripts to be added to Ubuntu $HOME directory (for the etcd and ignite-etcd configurations).
-- [env folder](REAMDME.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
+- [env folder](REAMDME.md): contains only one file named .profile-additions.  Add the contents of this file to the end of your .profile or .bashrc file.
 - [dev folder](README.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
 - [ig-ik8s-config folder](README.md): contains ignite-etcd specific configuration files.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,7 +2,7 @@
 *Temporary Disclaimer:*  This branch is complete in content and the instructions herein should be accurate, but this branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node etcd/ignite architecture. If futher developed, it should be converted into a Docker containers or some other more suitable state for multi-node deployment.
 
 The intended result is 5 servers: 3 server nodes, 1 client node (used only in the ignite-etcd configuration), and 1 benchmark node.  
-The run-time difference between the etcd and ignite-etcd configurations is that the benchmark node/app queries the 3 server-nodes:    
+The run-time difference between the etcd and ignite-etcd configuration is that the benchmark app/node queries the 3 server-nodes:    
 - directly (for the standard etcd configuration) and the igntite-etcd client/shim node is not used.  
 - indirectly (via the ignite-etcd client/node) for the ignite-etcd configuration.  
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@
 The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 
 The 3 server nodes and the 1 client node should contain in $HOME
-(1) At most two startup scripts from the env folder should be copied to the $HOME folder for each of the 3 server nodes and the 1 client node.
+(1) At most two startup scripts from the repo home folder should be copied to the $HOME folder for each of the 3 server nodes and the 1 client node.
     The startup scripts are:
     For server node 1: start-etcd1.sh and start-ignite.sh
     For server node 2: start-etcd2.sh and start-ignite.sh

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -107,7 +107,7 @@ etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \
 
 To install benchmark Go app:
 ----------------------------
-Note the /v3/ below -- make sure the /vX/ is the desired benchmark version)
+Note the /v3/ below -- make sure the /vX/ is the desired benchmark version.
 
 $ go get go.etcd.io/etcd/v3/tools/benchmark  
 $ benchmark --help

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,13 +3,14 @@
 
 The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 
-The 3 server nodes and the 1 client node should contain in $HOME:  
-(1) At most two startup scripts copied from the repo home folder to the $HOME folder (for each of the 3 server nodes and the 1 client node).  
-    The startup scripts are:  
+Each of the nodes should contain in $HOME:  
+(1) At most two startup (or benchmark) scripts copied from the repo/branch folder 'home' to the Unbuntu $HOME folder.  
+    The startup/benchmark scripts are:  
     For server node 1: start-etcd1.sh and start-ignite.sh  
     For server node 2: start-etcd2.sh and start-ignite.sh  
     For server node 3: start-etcd3.sh and start-ignite.sh  
-    For the client/shim node: start-ignite-etcd-shim.sh 
+    For the client/shim node: start-ignite-etcd-shim.sh
+    For the benchmark node: etcd-bm-write-all.sh and ignite-etcd-bm-write-all.sh
     
 (2) A 'dev' folder that should contain the following sub-folders:  
     etcd  go  igk8s  igk8s-config  ignite 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,7 +28,7 @@ Once fully configured, the etcd benchmarks can be run for only one configuration
 
 The benchmark folders are:
 
-- [Home folder](benchmark/dev-guide.md): startup files to be added to Ubuntu $HOME directory (i.e. startup scripts for the etcd and ignite-etcd configurations).
+- [home folder](benchmark/dev-guide.md): startup files to be added to Ubuntu $HOME directory (i.e. startup scripts for the etcd and ignite-etcd configurations).
 - [env folder](benchmark/design.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
 - [dev folder](benchmark/design.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
 - [ig-ik8s-config](ignite-etcd/README.md): contains ignite-etcd specific configuration files.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -9,7 +9,7 @@ Each of the nodes should contain in $HOME:
     For server node 1: start-etcd1.sh and start-ignite.sh  
     For server node 2: start-etcd2.sh and start-ignite.sh  
     For server node 3: start-etcd3.sh and start-ignite.sh  
-    For the client/shim node: start-ignite-etcd-shim.sh
+    For the client/shim node: start-ignite-etcd-shim.sh  
     For the benchmark node: etcd-bm-write-all.sh and ignite-etcd-bm-write-all.sh
     
 (2) A 'dev' folder that should contain the following sub-folders:  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,5 @@
 # benchmark
-Temporary Disclaimer:  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  Plus the current rendered display is eating line feeds?
+*Temporary Disclaimer:*  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  Plus the current rendered display is eating line feeds?
 
 The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 
@@ -16,7 +16,7 @@ The 3 server nodes and the 1 client node should contain in $HOME
 
 Please contact me for help/questions until I can get this branch in a fully clonable state.
 
-End Temporary Disclaimer.
+*End Temporary Disclaimer.*
 
 This branch contains the additional configuration files and instructions necessary to run *published etcd benchmarks*
 on Ubuntu vms, for either standard etcd or custom ignite-etcd configurations.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -41,7 +41,9 @@ add to ~/.profile:
 export PATH=$PATH:/usr/local/go/bin
 
 optionally add to ~/.profile a path for Go projects such as:
+
 export GOPATH=$HOME/dev/go
+
 export PATH=$PATH:$GOPATH/bin
 
 $ source .profile

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,175 @@
+# benchmark
+This benchmark branch contains the additional configuration files and instructions to run *published etcd benchmarks*
+on Ubuntu vms, for either standard etcd or custom ignite-etcd configurations.
+
+The folders/files herein are scripted for Unbuntu 20.0.4 and are organized into the folders assumed by the configuration scripts.
+However, this configuration can be easily changed for alternative Linux distros and/or other desired build configurations.
+
+Once configured, the benchmarks can be run for only configuration at a time (either for etcd or for ignite-ectd).
+
+The benchmark folders are:
+
+- [Home folder](benchmark/dev-guide.md): files to be added to Ubuntu $HOME directory (i.e. startup scripts for the etcd and ignite-etcd configurations).
+- [env folder](benchmark/design.md): contains one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
+- [dev folder](benchmark/design.md): top level folder in $HOME. ther benchmark folders, files, binaries, etc. will be added under this folder.
+- [ig-ik8s-config](ignite-etcd/README.md): contains itnite-etcd specific configuration files.
+
+Below are detailed instructions for installing and building the benchmark applications and etcd/ignite-etcd servers.
+
+To install Java 8 on Ubunutu server/machine:
+-------------------------------------------
+sudo apt update
+sudo apt install openjdk-8-jdk openjdk-8-jre
+java -version
+
+add to ~/.profile:
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"
+
+$ source .profile
+
+
+To install Go on Ubuntu server/machine:
+--------------------------------------
+(besure to edit the Go version you want, e.g. 16.8 below)
+wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+
+add to ~/.profile:
+export PATH=$PATH:/usr/local/go/bin
+
+optionally add to ~/.profile a path for Go projects such as:
+export GOPATH=$HOME/dev/go
+export PATH=$PATH:$GOPATH/bin
+
+$ source .profile
+$ go version
+
+To install etcd
+----------------
+(1) Open in a browser the desired release link, e.g. for 3.5: https://github.com/etcd-io/etcd/releases/tag/v3.5.0
+(2) Copy the install script (displayed on the etcd webpage) directly into your ubuntu terminal session (maybe they will change that someday :) 
+(3) The copied script will download etcd into folder: /tmp/etcd-download-test
+(4) copy the three etcd binaries (etcd, etcdctl, etcdutl) to /usr/local/bin:
+    sudo cp /tmp/etcd-download-test/etcd /usr/local/bin/
+    sudo cp /tmp/etcd-download-test/etcdctl /usr/local/bin/
+    sudo cp /tmp/etcd-download-test/etcdutl /usr/local/bin/
+(5) verify with:  etcd -version
+      etcd Version: 3.5.0
+      Git SHA: 946a5a6f2
+      Go Version: go1.16.3
+      Go OS/Arch: linux/amd64
+(6) Move or delete the /tmp/ectcd-download-test folder (and its contents) as desired (or just leave it as is).  No other etcd files are not needed for this project.
+
+VERY IMPORTANT: FOR THE FIRST TIME YOU START UP A MULTI_NODE ETCD CLUSTER
+-------------------------------------------------------------------------
+Starting etcd clusters is generally very easy (per on-line documentation).  But restarting, resetting, clearing etcd clusters, once started can be very confusing until some basics are understood.
+(1) Every time you start a "NEW" cluster (not restart an already existing cluster), you must provide a new unqiue token ID (see the .profile example below).
+(2) If you want to start over with a new cluster, you should delete the etcd db directory (called default.etcd unless you rename it) on all servers, AND change the new cluster token ID (in the .profile example below) -- this is very important or very strange things start to happen.
+(3) There are probably better ways to do this, but they require a good deal more understanding of etcd (refer to the documentation if you need this understanding).
+(4) Basically, understand and set these environment variables (any time you start a new cluster), and uncomment them after the cluster is fully up (yes, wierd).
+#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
+#export ETCD_INITIAL_CLUSTER_STATE=new
+#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.
+
+Then to start an etcd cluster using the command below on each etcd server (in a script or terminal session):
+(The --name parameter is optional.  See the full .profile example below to see how the INITIIAL CLUSTER and SERVER_IP variables are set and automatically added)
+etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \
+  --listen-peer-urls http://${SERVER_1_IP}:2380 \
+  --listen-client-urls http://${SERVER_1_IP}:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://${SERVER_1_IP}:2379 \
+
+
+To install benchmark: (note the /v3/ below -- make sure the benchmark is for your desired version)
+--------------------------------------------------------------------------------------------------
+
+$ go get go.etcd.io/etcd/v3/tools/benchmark
+$ benchmark --help
+
+For the ignite-etc installs, create a home directory, such as dev:
+------------------------------------------------------------------
+cd $HOME
+mkdir dev
+
+
+To install ignite v2.10.0 (binaries only)
+-----------------------------------------
+cd $HOME/dev
+wget https://archive.apache.org/dist/ignite/2.10.0/apache-ignite-2.10.0-bin.zip
+
+If necessary (install unzip)
+sudo apt-get install unzip
+unzip apache-ignite-2.10.0-bin.zip
+
+mv apache-ignite-2.10.0-bin ignite  (simplify name to ignite)
+rm apache-ignite-2.10.0-bin.zip (delete the .zip file if you want to).
+
+To install and build ignite-in-k8s
+-----------------------------------
+(1) Make sure you are in the 'dev' directory (or the installation folder of choice)
+(2) $ git clone https://github.com/gridgain-solutions/ignite-in-k8s.git
+(3) optionally rename folder to shorter name like: igk8s
+    This project generates a really long path, that can exceed limits on Windows, but is probably not a problem on Linux.
+(4) cd igk8s/ignite-etcd
+(5) ./gradlew installDist (to build the project)
+
+
+Setting up ETCD Endpoints (to use in etcdcl and benchmark commands)
+-------------------------------------------------------------------
+All etcdctl and benchmark commands are issused to the same listening port (2379), so set up some env variables for the different etcd configs you want to test.
+For etcd -- this will be a list of (n) etcd servers.  For ignite-etcd, it may be a single etcd-shim server.  See examples below:
+
+# Set etcd endpoints (for benchmark and client apps)
+export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379
+export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379
+
+Then in etcdctl commands, add the --endpoints=$ETCD_ENDPOINTS  (or IGNITE_ETCD_ENDPOINTS) to the etcdctl command you want to invoke.  (note the = sign).
+For the benchmark program, omit the '=', so add --endpoints $ETCD_ENDPOINTS  to the benchmark command.
+
+With the two environments variables, you should be able to run all etcdctl or benchmark commands for either etcd or ignite-etcd.  But of course you can only have one test configuration active at a time (if you are using the same machines).  As both etcd and ignite_etcd have to listen on the same port 2379.
+
+Example .profile 
+Below is an example of the env variables and settings added to the ubuntu .profile file (for the tests ran in GCE):
+
+# Set Java Home and ignite optimized JVM settings
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"
+
+# Set GO environment variables and update PATH
+export GOPATH=$HOME/dev/go
+export PATH=$PATH:$GOPATH/bin
+export PATH=$PATH:/usr/local/go/bin
+
+# Set ignite HOME and update PATH
+export IGNITE_HOME=${HOME}/dev/ignite
+export PATH=$PATH:${IGNITE_HOME}/bin
+
+# Set ignite-etcd HOME and update PATH
+export IGNITE_ETCD_CONFIG=${HOME}/dev/igk8s-configs
+export IGNITE_ETCD_HOME=${HOME}/dev/igk8s/ignite-etcd/build/install/ignite-etcd
+export PATH=$PATH:${IGNITE_ETCD_HOME}/bin
+
+# Set Internal (Static) Server IPs
+export SERVER_1_IP=10.162.0.2
+export SERVER_2_IP=10.162.0.3
+export SERVER_3_IP=10.162.0.11
+export SERVER_4_IP=10.162.0.9
+export SERVER_5_IP=10.162.0.10
+
+# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables
+export ETCDCTL_API=3
+export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd
+
+# Set these only when starting up a new etcd cluster for the first time!
+# After the cluster is up and running, comment out these settings (and run source .profile)
+#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
+#export ETCD_INITIAL_CLUSTER_STATE=new
+#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.
+
+# Set etcd endpoints (for benchmark and client apps)
+export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379
+export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379
+
+
+
+
+ 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -34,6 +34,7 @@ $ source .profile
 To install Go on Ubuntu server/machine:
 --------------------------------------
 *Be sure to edit the Go version you want, e.g. 16.8 below*
+
 wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 
 add to ~/.profile:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -97,7 +97,7 @@ Starting etcd clusters is generally very easy (per on-line documentation).  But 
 (4) Basically, enable/set these environment variables any time you start a new cluster from scratch, and comment them out after the cluster is fully up (yes, wierd).  
 export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
 export ETCD_INITIAL_CLUSTER_STATE=new  
-export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
+export ETCD_INITIAL_CLUSTER_TOKEN=INITIAL_TOKEN_1  # <-- ensure that this value is changed any time a new cluster is started from scratch.  
 
 Then to start an etcd cluster, run a etcd start command (like the one below) for each etcd server node (in a script or terminal session):  
 The --name parameter is important and must be the same as in the .profile env variables.  
@@ -204,7 +204,7 @@ export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd
 \# After the cluster is up and running, comment out these settings (and run source .profile)  
 export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
 export ETCD_INITIAL_CLUSTER_STATE=new  
-export ETCD_INITIAL_CLUSTER_TOKEN=INITIAL_TOKEN_1 # <-- change/ensure that this value is unique/different each time a new cluster is started.  
+export ETCD_INITIAL_CLUSTER_TOKEN=INITIAL_TOKEN_1 # <-- ensure that this value is changed/different each time a new cluster is started.  
 
 \# Set etcd endpoints (for benchmark and client apps)  
 export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,7 +2,7 @@
 *Temporary Disclaimer:*  This branch is complete in content and the instructions herein should be accurate, but this branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node etcd/ignite architecture. If futher developed, it should be converted into a Docker containers or some other more suitable state for multi-node deployment.
 
 The intended result is 5 servers: 3 server nodes, 1 client node (used only in the ignite-etcd configuration), and 1 benchmark node.  
-The run-time difference between the etcd and ignite-etcd configuration is that the benchmark app/node queries the 3 server-nodes:    
+The run-time difference between the etcd and ignite-etcd configuration is that the benchmark app/node queries the 3 server-nodes:
 - directly (for the standard etcd configuration) and the igntite-etcd client/shim node is not used.  
 - indirectly (via the ignite-etcd client/node) for the ignite-etcd configuration.  
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,5 @@
 # benchmark
-*Temporary Disclaimer:*  This branch is complete in content, and the instructions herein are accurate, but this not branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node architecture. If futher developed, it should be converted into a Docker containers or some other more suitable state for multi-node deployment.
+*Temporary Disclaimer:*  This branch is complete in content and the instructions herein should be accurate, but this branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node etcd/ignite architecture. If futher developed, it should be converted into a Docker containers or some other more suitable state for multi-node deployment.
 
 The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,7 +1,10 @@
 # benchmark
 *Temporary Disclaimer:*  This branch is complete in content and the instructions herein should be accurate, but this branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node etcd/ignite architecture. If futher developed, it should be converted into a Docker containers or some other more suitable state for multi-node deployment.
 
-The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
+The intended result is 5 servers: 3 server nodes, 1 client node (used only in the ignite-etcd configuration), and 1 benchmark node.  
+The run-time difference between the etcd and ignite-etcd configurations is that the benchmark node/app queries the 3 server-nodes:    
+- directly (for the standard etcd configuration) and the igntite-etcd client/shim node is not used.  
+- indirectly (via the ignite-etcd client/node) for the ignite-etcd configuration.  
 
 Each of the nodes should contain in $HOME:  
 (1) At most two startup (or benchmark) scripts copied from the repo/branch folder 'home' to the Unbuntu $HOME folder.  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -55,7 +55,7 @@ $ source .profile
 
 To install Go on Ubuntu server/machine:
 --------------------------------------
-*Be sure to edit the Go version you want, e.g. 16.8 below*
+*Be sure to specify the Go version you want, e.g. 16.8 below, and please note the etcd installations do not yet work for Go 17.X*
 
 wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -31,10 +31,10 @@ Once fully configured, the etcd benchmarks can be run for only one configuration
 
 The benchmark folders are:
 
-- [home folder](benchmark/README.md): startup and benchmark scripts to be added to Ubuntu $HOME directory (for the etcd and ignite-etcd configurations).
-- [env folder](benchmark/REAMDME.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
-- [dev folder](benchmark/README.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
-- [ig-ik8s-config folder](benchmark/README.md): contains ignite-etcd specific configuration files.
+- [home folder](README.md): startup and benchmark scripts to be added to Ubuntu $HOME directory (for the etcd and ignite-etcd configurations).
+- [env folder](REAMDME.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
+- [dev folder](README.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
+- [ig-ik8s-config folder](README.md): contains ignite-etcd specific configuration files.
 
 Below are the detailed instructions for installing and building the benchmark applications and etcd/ignite-etcd servers.
 **Please note** that these instructions incrementally add all the .profile extensions listed above in .profile-additions file.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -153,7 +153,7 @@ Then in etcdctl commands, add the --endpoints=$ETCD_ENDPOINTS  (or IGNITE_ETCD_E
 
 For the benchmark program, omit the '=', so add --endpoints $ETCD_ENDPOINTS  to the benchmark command.
 
-**Examples:**
+**Examples:**  
 etcdctl --endpoints=$ETCD_ENDPOINTS put foo bar  
 etcdctl --endpoints=$IGNITE_ETCD_ENDPOINTS put foo bar  
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,7 @@
 # benchmark
-Temporary Disclaimer:  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
+Temporary Disclaimer:  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  Plus the current rendered display is eating line feeds?
+
+The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 
 The 3 server nodes and the 1 client node should contain in $HOME
 (1) At most two startup scripts from the env folder should be copied to the $HOME folder for each of the 3 server nodes and the 1 client node.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -15,6 +15,7 @@ The 3 server nodes and the 1 client node should contain in $HOME
 (3) The benchmark node should contain one benchmark folder under $HOME.
 
 Please contact me for help/questions until I can get this branch in a fully clonable state.
+
 End Temporary Disclaimer.
 
 This branch contains the additional configuration files and instructions necessary to run *published etcd benchmarks*

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -14,7 +14,7 @@ The 3 server nodes and the 1 client node should contain in $HOME:
 (2) A 'dev' folder that should contain the following sub-folders:  
     etcd  go  igk8s  igk8s-config  ignite 
     
-(3) The benchmark node should contain one benchmark folder under $HOME.
+(3) The benchmark node (just for consistency) can have the same setup above, but much of it will not be used.  Instead, it will have one addition, the benchmark Go app. The benchmark installation instructions herein will install the benchmark app into GoPath and the app itself into $HOME/dev/go/bin.  It is runnable from any locaton on the server.
 
 Please contact me for help/questions until I can get this branch in a fully clonable state.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -98,7 +98,7 @@ Starting etcd clusters is generally very easy (per on-line documentation).  But 
 
 Then to start an etcd cluster, run a etcd start command (like the one below) for each etcd server node (in a script or terminal session):  
 The --name parameter is important and must be the same as in the .profile env variables.  
-See the full **Example .profile** below to see how the INITIIAL CLUSTER and SERVER_IP variables should be set). 
+See the full **Example .profile** below to see how the INITIAL CLUSTER and SERVER_IP variables should be set). 
 
 etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \  
   --listen-peer-urls http://${SERVER_1_IP}:2380 \  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -9,11 +9,11 @@ The run-time difference between the etcd and ignite-etcd configuration is that t
 Each of the nodes should contain in $HOME:  
 (1) At most two startup (or benchmark) scripts copied from the repo/branch folder 'home' to the Unbuntu $HOME folder.  
     The startup/benchmark scripts are:  
-    For server node 1: start-etcd1.sh and start-ignite.sh  
-    For server node 2: start-etcd2.sh and start-ignite.sh  
-    For server node 3: start-etcd3.sh and start-ignite.sh  
-    For the client/shim node: start-ignite-etcd-shim.sh  
-    For the benchmark node: etcd-bm-write-all.sh and ignite-etcd-bm-write-all.sh
+ - *For server node 1:* start-etcd1.sh and start-ignite.sh
+ - *For server node 2:* start-etcd2.sh and start-ignite.sh
+ - *For server node 3:* start-etcd3.sh and start-ignite.sh 
+ - *For the ignite client/shim node:* start-ignite-etcd-shim.sh
+ - *For the benchmark node:* etcd-bm-write-all.sh and ignite-etcd-bm-write-all.sh
     
 (2) A 'dev' folder that should contain the following sub-folders:  
     etcd  go  igk8s  igk8s-config  ignite 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -24,7 +24,7 @@ on Ubuntu vms, for either standard etcd or custom ignite-etcd configurations.
 The folders/files herein are scripted for Unbuntu 20.0.4 and are organized into the folders assumed by the current configuration scripts.
 However, these configuration files can be easily changed for alternative Linux distros and/or other desired build configurations.
 
-Once configured, the etcd benchmarks can be run for only configuration at a time (either for etcd or for ignite-ectd).
+Once fully configured, the etcd benchmarks can be run for only one configuration at a time (either for etcd or for ignite-ectd).
 
 The benchmark folders are:
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -95,9 +95,9 @@ Starting etcd clusters is generally very easy (per on-line documentation).  But 
 (2) If you want to start over with a new cluster, you should delete the etcd db directory (called default.etcd unless you rename it) on all servers, AND change the new cluster token ID (in the .profile export example in step 4 below) -- this is very important or very strange things start to happen.  
 (3) There are probably better ways to do this, but they require a good deal more understanding of etcd (refer to the documentation if you need this understanding).  
 (4) Basically, understand and set these environment variables (any time you start a new cluster), and uncomment them after the cluster is fully up (yes, wierd).  
-#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
-#export ETCD_INITIAL_CLUSTER_STATE=new  
-#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
+export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
+export ETCD_INITIAL_CLUSTER_STATE=new  
+export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
 
 Then to start an etcd cluster, run a etcd start command (like the one below) for each etcd server node (in a script or terminal session):  
 The --name parameter is important and must be the same as in the .profile env variables.  
@@ -202,9 +202,9 @@ export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd
 
 \# Set these only when starting up a new etcd cluster for the first time!  
 \# After the cluster is up and running, comment out these settings (and run source .profile)  
-\#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
-\#export ETCD_INITIAL_CLUSTER_STATE=new  
-\#export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
+export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
+export ETCD_INITIAL_CLUSTER_STATE=new  
+export ETCD_INITIAL_CLUSTER_TOKEN=INITIAL_TOKEN_1 # <-- change/ensure that this value is unique/different each time a new cluster is started.  
 
 \# Set etcd endpoints (for benchmark and client apps)  
 export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -105,8 +105,9 @@ etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \
   --listen-client-urls http://${SERVER_1_IP}:2379,http://127.0.0.1:2379 \  
   --advertise-client-urls http://${SERVER_1_IP}:2379
 
-To install benchmark: (note the /v3/ below -- make sure the benchmark is for your desired version)
---------------------------------------------------------------------------------------------------
+To install benchmark Go app:
+----------------------------
+Note the /v3/ below -- make sure the /vX/ is the desired benchmark version)
 
 $ go get go.etcd.io/etcd/v3/tools/benchmark  
 $ benchmark --help

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,15 +3,15 @@
 
 The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 
-The 3 server nodes and the 1 client node should contain in $HOME
-(1) At most two startup scripts from the repo home folder should be copied to the $HOME folder for each of the 3 server nodes and the 1 client node.
-    The startup scripts are:
-    For server node 1: start-etcd1.sh and start-ignite.sh
-    For server node 2: start-etcd2.sh and start-ignite.sh
-    For server node 3: start-etcd3.sh and start-ignite.sh
-    For the client/shim node: start-ignite-etcd-shim.sh
-(2) A 'dev' folder that should contain the following sub-folders:
-    etcd  go  igk8s  igk8s-config  ignite
+The 3 server nodes and the 1 client node should contain in $HOME:  
+(1) At most two startup scripts copied from the repo home folder to the $HOME folder (for each of the 3 server nodes and the 1 client node).  
+    The startup scripts are:  
+    For server node 1: start-etcd1.sh and start-ignite.sh  
+    For server node 2: start-etcd2.sh and start-ignite.sh  
+    For server node 3: start-etcd3.sh and start-ignite.sh  
+    For the client/shim node: start-ignite-etcd-shim.sh  
+(2) A 'dev' folder that should contain the following sub-folders:  
+    etcd  go  igk8s  igk8s-config  ignite  
 (3) The benchmark node should contain one benchmark folder under $HOME.
 
 Please contact me for help/questions until I can get this branch in a fully clonable state.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -34,7 +34,7 @@ The benchmark folders are:
 - [home folder](benchmark/dev-guide.md): startup and benchmark scripts to be added to Ubuntu $HOME directory (for the etcd and ignite-etcd configurations).
 - [env folder](benchmark/design.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
 - [dev folder](benchmark/design.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
-- [ig-ik8s-config](ignite-etcd/README.md): contains ignite-etcd specific configuration files.
+- [ig-ik8s-config folder](ignite-etcd/README.md): contains ignite-etcd specific configuration files.
 
 Below are the detailed instructions for installing and building the benchmark applications and etcd/ignite-etcd servers.
 **Please note** that these instructions incrementally add all the .profile extensions listed above in .profile-additions file.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -166,7 +166,7 @@ benchmark --endpoints=$IGNITE_ETCD_ENDPOINTS --conns=100 --clients=1000 put --ke
 With the two environments variables, you should be able to run all etcdctl or benchmark commands for either etcd or ignite-etcd.  But of course you can only have one test configuration active at a time (if you are using the same machines).  As both etcd and ignite_etcd have to listen on the same port 2379.
 
 # Example .profile 
-Below is an example of the env variables and settings added to the ubuntu .profile file (for the tests ran in GCE):
+Below is an example of all of the env variable settings that should be added to the Ubuntu .profile file (for this benchmark branch project):
 
 \# Set Java Home and ignite optimized JVM settings  
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -190,11 +190,11 @@ export IGNITE_ETCD_HOME=${HOME}/dev/igk8s/ignite-etcd/build/install/ignite-etcd
 export PATH=$PATH:${IGNITE_ETCD_HOME}/bin  
 
 \# Set Internal (Static) Server IPs  
-export SERVER_1_IP=10.162.0.2  
-export SERVER_2_IP=10.162.0.3  
-export SERVER_3_IP=10.162.0.11  
-export SERVER_4_IP=10.162.0.9  
-export SERVER_5_IP=10.162.0.10  
+export SERVER_1_IP=10.162.0.1  
+export SERVER_2_IP=10.162.0.2  
+export SERVER_3_IP=10.162.0.3  
+export SERVER_4_IP=10.162.0.4  
+export SERVER_5_IP=10.162.0.5  
 
 \# Set etcd configuration flags (common across all etcd nodes) using reserved etcd environment variables  
 export ETCDCTL_API=3  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -88,8 +88,8 @@ To install etcd
 VERY IMPORTANT: FOR THE FIRST TIME YOU START UP A MULTI_NODE ETCD CLUSTER
 -------------------------------------------------------------------------
 Starting etcd clusters is generally very easy (per on-line documentation).  But restarting, resetting, clearing etcd clusters, once started can be very confusing until some basics are understood.  
-(1) Every time you start a "NEW" cluster (not restart an already existing cluster), you must provide a new unqiue token ID (see the .profile example below).  
-(2) If you want to start over with a new cluster, you should delete the etcd db directory (called default.etcd unless you rename it) on all servers, AND change the new cluster token ID (in the .profile example below) -- this is very important or very strange things start to happen.  
+(1) Every time you start a "NEW" cluster (not restart an already existing cluster), you must provide a new unqiue token ID (see the .profile export examples in step 4 below).  
+(2) If you want to start over with a new cluster, you should delete the etcd db directory (called default.etcd unless you rename it) on all servers, AND change the new cluster token ID (in the .profile export example in step 4 below) -- this is very important or very strange things start to happen.  
 (3) There are probably better ways to do this, but they require a good deal more understanding of etcd (refer to the documentation if you need this understanding).  
 (4) Basically, understand and set these environment variables (any time you start a new cluster), and uncomment them after the cluster is fully up (yes, wierd).  
 #export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -46,7 +46,7 @@ sudo apt update
 sudo apt install openjdk-8-jdk openjdk-8-jre  
 java -version
 
-add to ~/.profile:  
+Add to ~/.profile:  
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64  
 export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"  
 
@@ -59,10 +59,10 @@ To install Go on Ubuntu server/machine:
 
 wget -c https://dl.google.com/go/go1.16.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 
-add to ~/.profile:  
+Add to ~/.profile:  
 export PATH=$PATH:/usr/local/go/bin
 
-optionally add to ~/.profile a path for Go projects such as:  
+Add to ~/.profile the path for Go projects, such as:  
 export GOPATH=$HOME/dev/go  
 export PATH=$PATH:$GOPATH/bin
 
@@ -74,11 +74,11 @@ To install etcd
 (1) Open in a browser the desired release link, e.g. for 3.5: https://github.com/etcd-io/etcd/releases/tag/v3.5.0  
 (2) Copy the install script (displayed on the etcd webpage) directly into your ubuntu terminal session (maybe they will change that someday :)  
 (3) The copied script will download etcd into folder: /tmp/etcd-download-test  
-(4) copy the three etcd binaries (etcd, etcdctl, etcdutl) to /usr/local/bin:  
+(4) Copy the three etcd binaries (etcd, etcdctl, etcdutl) to /usr/local/bin:  
     sudo cp /tmp/etcd-download-test/etcd /usr/local/bin/  
     sudo cp /tmp/etcd-download-test/etcdctl /usr/local/bin/  
     sudo cp /tmp/etcd-download-test/etcdutl /usr/local/bin/  
-(5) verify with:  etcd -version  
+(5) Verify with:  etcd -version  
       etcd Version: 3.5.0  
       Git SHA: 946a5a6f2  
       Go Version: go1.16.3  
@@ -123,10 +123,11 @@ To install ignite v2.10.0 (binaries only)
 cd $HOME/dev  
 wget https://archive.apache.org/dist/ignite/2.10.0/apache-ignite-2.10.0-bin.zip
 
-If necessary (install unzip)  
+If necessary (install unzip):  
 sudo apt-get install unzip  
 unzip apache-ignite-2.10.0-bin.zip  
 
+Rename ignite folder and delete zip file:  
 mv apache-ignite-2.10.0-bin ignite  (simplify name to ignite)  
 rm apache-ignite-2.10.0-bin.zip (delete the .zip file if you want to).  
 
@@ -138,7 +139,6 @@ To install and build ignite-in-k8s
     This project generates a really long path, that can exceed limits on Windows, but is probably not a problem on Linux.  
 (4) cd igk8s/ignite-etcd  
 (5) ./gradlew installDist (to build the project)  
-
 
 Setting up ETCD Endpoints (to use in etcdcl and benchmark commands)
 -------------------------------------------------------------------

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,4 +1,20 @@
 # benchmark
+Temporary Disclaimer:  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  The intended result is 5 servers, 3 server nodes, 1 client/shim node, and 1 benchmark node.
+
+The 3 server nodes and the 1 client node should contain in $HOME
+(1) At most two startup scripts from the env folder should be copied to the $HOME folder for each of the 3 server nodes and the 1 client node.
+    The startup scripts are:
+    For server node 1: start-etcd1.sh and start-ignite.sh
+    For server node 2: start-etcd2.sh and start-ignite.sh
+    For server node 3: start-etcd3.sh and start-ignite.sh
+    For the client/shim node: start-ignite-etcd-shim.sh
+(2) A 'dev' folder that should contain the following sub-folders:
+    etcd  go  igk8s  igk8s-config  ignite
+(3) The benchmark node should contain one benchmark folder under $HOME.
+
+Please contact me for help/questions until I can get this branch in a fully clonable state.
+End Temporary Disclaimer.
+
 This branch contains the additional configuration files and instructions necessary to run *published etcd benchmarks*
 on Ubuntu vms, for either standard etcd or custom ignite-etcd configurations.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -149,8 +149,19 @@ For etcd -- this will be a list of (n) etcd servers.  For ignite-etcd, it may be
 export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379  
 export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379
 
-Then in etcdctl commands, add the --endpoints=$ETCD_ENDPOINTS  (or IGNITE_ETCD_ENDPOINTS) to the etcdctl command you want to invoke.  (note the = sign).  
+Then in etcdctl commands, add the --endpoints=$ETCD_ENDPOINTS  (or IGNITE_ETCD_ENDPOINTS) to the etcdctl command you want to invoke (note the = sign).  
+
 For the benchmark program, omit the '=', so add --endpoints $ETCD_ENDPOINTS  to the benchmark command.
+
+**Examples:**
+etcdctl --endpoints=$ETCD_ENDPOINTS put foo bar  
+etcdctl --endpoints=$IGNITE_ETCD_ENDPOINTS put foo bar  
+
+benchmark endpoints $ETCD_ENDPOINTS put  
+benchmark endpoints $IGNITE_ETCD_ENDPOINTS put  
+
+benchmark --endpoints=$ETCD_ENDPOINTS --conns=100 --clients=1000 put --key-size=8 --sequential-keys --total=100000 --val-size=256
+benchmark --endpoints=$IGNITE_ETCD_ENDPOINTS --conns=100 --clients=1000 put --key-size=8 --sequential-keys --total=100000 --val-size=256
 
 With the two environments variables, you should be able to run all etcdctl or benchmark commands for either etcd or ignite-etcd.  But of course you can only have one test configuration active at a time (if you are using the same machines).  As both etcd and ignite_etcd have to listen on the same port 2379.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -94,7 +94,7 @@ Starting etcd clusters is generally very easy (per on-line documentation).  But 
 (1) Every time you start a "NEW" cluster (not restart an already existing cluster), you must provide a new unqiue token ID (see the .profile export examples in step 4 below).  
 (2) If you want to start over with a new cluster, you should delete the etcd db directory (called default.etcd unless you rename it) on all servers, AND change the new cluster token ID (in the .profile export example in step 4 below) -- this is very important or very strange things start to happen.  
 (3) There are probably better ways to do this, but they require a good deal more understanding of etcd (refer to the documentation if you need this understanding).  
-(4) Basically, understand and set these environment variables (any time you start a new cluster), and uncomment them after the cluster is fully up (yes, wierd).  
+(4) Basically, enable/set these environment variables any time you start a new cluster from scratch, and comment them out after the cluster is fully up (yes, wierd).  
 export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
 export ETCD_INITIAL_CLUSTER_STATE=new  
 export ETCD_INITIAL_CLUSTER_TOKEN=??? # <-- change/ensure that this value is unique/different each time a new cluster is started.  
@@ -200,7 +200,7 @@ export SERVER_5_IP=10.162.0.10
 export ETCDCTL_API=3  
 export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd
 
-\# Set these only when starting up a new etcd cluster for the first time!  
+\# Enable/set these only when starting up a new etcd cluster for the first time!  
 \# After the cluster is up and running, comment out these settings (and run source .profile)  
 export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"  
 export ETCD_INITIAL_CLUSTER_STATE=new  

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -31,7 +31,7 @@ Once fully configured, the etcd benchmarks can be run for only one configuration
 
 The benchmark folders are:
 
-- [home folder](benchmark/dev-guide.md): startup files to be added to Ubuntu $HOME directory (i.e. startup scripts for the etcd and ignite-etcd configurations).
+- [home folder](benchmark/dev-guide.md): startup and benchmark scripts to be added to Ubuntu $HOME directory (for the etcd and ignite-etcd configurations).
 - [env folder](benchmark/design.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
 - [dev folder](benchmark/design.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
 - [ig-ik8s-config](ignite-etcd/README.md): contains ignite-etcd specific configuration files.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,5 @@
 # benchmark
-Temporary Disclaimer:  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  The intended result is 5 servers, 3 server nodes, 1 client/shim node, and 1 benchmark node.
+Temporary Disclaimer:  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 
 The 3 server nodes and the 1 client node should contain in $HOME
 (1) At most two startup scripts from the env folder should be copied to the $HOME folder for each of the 3 server nodes and the 1 client node.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,5 @@
 # benchmark
-*Temporary Disclaimer:*  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.  Plus the current rendered display is eating line feeds?
+*Temporary Disclaimer:*  This branch is complete in content, but is not yet in a clonable state.  The instructions herein are not yet fully accurate, and perhaps should be converted into a Docker container version.
 
 The intended result is 5 servers: 3 server nodes, 1 client/shim node, and 1 benchmark node.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,5 +1,5 @@
 # benchmark
-*Temporary Disclaimer:*  This branch is complete in content and the instructions herein should be accurate, but this branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node etcd/ignite architecture. If futher developed, it should be converted into a Docker containers or some other more suitable state for multi-node deployment.
+*Temporary Disclaimer:*  This branch is complete in content and the instructions herein should be accurate, but this branch is not yet in a clonable state, because it contains mostly instructions, scripts, and config files for a multi-node etcd/ignite architecture. If futher developed, it should be converted into Docker containers or some other more suitable state for multi-node deployment.
 
 The intended result is 5 servers: 3 server nodes, 1 client node (used only in the ignite-etcd configuration), and 1 benchmark node.  
 The run-time difference between the etcd and ignite-etcd configuration is that the benchmark app/node queries the 3 server-nodes:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -83,7 +83,7 @@ To install etcd
       Git SHA: 946a5a6f2  
       Go Version: go1.16.3  
       Go OS/Arch: linux/amd64  
-(6) Move or delete the /tmp/ectcd-download-test folder (and its contents) as desired (or just leave it as is).  No other etcd files are not needed for this project.  
+(6) For convenience, rename the 'etcd-download-test' folder to 'etcd' and move it to the $HOME/dev folder.  Alternatively, just leave it as is, or delete it, as it will not be used further in this project (since the three etcd binaries were copied to /usr/local/bin in step 3 above).
 
 VERY IMPORTANT: FOR THE FIRST TIME YOU START UP A MULTI_NODE ETCD CLUSTER
 -------------------------------------------------------------------------

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,20 +1,22 @@
 # benchmark
-This benchmark branch contains the additional configuration files and instructions to run *published etcd benchmarks*
+This branch contains the additional configuration files and instructions necessary to run *published etcd benchmarks*
 on Ubuntu vms, for either standard etcd or custom ignite-etcd configurations.
 
-The folders/files herein are scripted for Unbuntu 20.0.4 and are organized into the folders assumed by the configuration scripts.
-However, this configuration can be easily changed for alternative Linux distros and/or other desired build configurations.
+The folders/files herein are scripted for Unbuntu 20.0.4 and are organized into the folders assumed by the current configuration scripts.
+However, these configuration files can be easily changed for alternative Linux distros and/or other desired build configurations.
 
-Once configured, the benchmarks can be run for only configuration at a time (either for etcd or for ignite-ectd).
+Once configured, the etcd benchmarks can be run for only configuration at a time (either for etcd or for ignite-ectd).
 
 The benchmark folders are:
 
-- [Home folder](benchmark/dev-guide.md): files to be added to Ubuntu $HOME directory (i.e. startup scripts for the etcd and ignite-etcd configurations).
-- [env folder](benchmark/design.md): contains one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
-- [dev folder](benchmark/design.md): top level folder in $HOME. ther benchmark folders, files, binaries, etc. will be added under this folder.
-- [ig-ik8s-config](ignite-etcd/README.md): contains itnite-etcd specific configuration files.
+- [Home folder](benchmark/dev-guide.md): startup files to be added to Ubuntu $HOME directory (i.e. startup scripts for the etcd and ignite-etcd configurations).
+- [env folder](benchmark/design.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
+- [dev folder](benchmark/design.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
+- [ig-ik8s-config](ignite-etcd/README.md): contains ignite-etcd specific configuration files.
 
-Below are detailed instructions for installing and building the benchmark applications and etcd/ignite-etcd servers.
+Below are the detailed instructions for installing and building the benchmark applications and etcd/ignite-etcd servers.
+**Please note** that these instructions incrementally add all the .profile extensions listed above in .profile-additions file.
+So you can copy all the .profile extensions at once, or build them step by step, and compare them at the end.
 
 To install Java 8 on Ubunutu server/machine:
 -------------------------------------------

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -31,10 +31,10 @@ Once fully configured, the etcd benchmarks can be run for only one configuration
 
 The benchmark folders are:
 
-- [home folder](benchmark/dev-guide.md): startup and benchmark scripts to be added to Ubuntu $HOME directory (for the etcd and ignite-etcd configurations).
-- [env folder](benchmark/design.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
-- [dev folder](benchmark/design.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
-- [ig-ik8s-config folder](ignite-etcd/README.md): contains ignite-etcd specific configuration files.
+- [home folder](benchmark/README.md): startup and benchmark scripts to be added to Ubuntu $HOME directory (for the etcd and ignite-etcd configurations).
+- [env folder](benchmark/REAMDME.md): contains only one file named .profile-additions.  Add all the additions in this file to the end of your .profile or .bashrc file.
+- [dev folder](benchmark/README.md): top level folder under $HOME. All other benchmark folders, files, binaries, etc. will be added under this 'dev' folder.
+- [ig-ik8s-config folder](benchmark/README.md): contains ignite-etcd specific configuration files.
 
 Below are the detailed instructions for installing and building the benchmark applications and etcd/ignite-etcd servers.
 **Please note** that these instructions incrementally add all the .profile extensions listed above in .profile-additions file.

--- a/benchmark/linux/dev/igk8s-config/etcd-shim-node.xml
+++ b/benchmark/linux/dev/igk8s-config/etcd-shim-node.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+
+        <!-- Configure etcd shim nodes as client nodes, not server nodes -->
+        <property name="clientMode" value="true"/>
+
+        <!-- Enable peer class loading -->
+        <property name="peerClassLoadingEnabled" value="true"/>
+
+         <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <lis>
+                                <value>ig-etcd-1:47500</value>
+                                <value>ig-etcd-2:47500</value>
+                                <value>ig-etcd-3:47500</value>
+                                <value>ig-etcd-4:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+    </bean>
+</beans>

--- a/benchmark/linux/dev/igk8s-config/ignite-server-node.xml
+++ b/benchmark/linux/dev/igk8s-config/ignite-server-node.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+
+        <!-- Enable peer class loading -->
+        <property name="peerClassLoadingEnabled" value="true"/>
+
+         <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <lis>
+                                <value>ig-etcd-1:47500</value>
+                                <value>ig-etcd-2:47500</value>
+                                <value>ig-etcd-3:47500</value>
+                                <value>ig-etcd-4:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+    </bean>
+</beans>

--- a/benchmark/linux/env/.profile-additions
+++ b/benchmark/linux/env/.profile-additions
@@ -1,0 +1,49 @@
+# Add the path and environment variables below to the end of your Ubuntu .profile file (or to an alternate/preferred env file, such as .bashrc)
+# Ensure that the settings below (or equivalent) are activated on server start-up/log-in for each etcd/ignite-etcd node, both server and client nodes.
+# The only node that doesn't strictly need all of these settings is the benchmark server node itself (but its probably easier just to add them anyway).
+
+# These settings assume a 'dev' folder in the $HOME folder, under which the etcd, ignite-etcd, and Go-project installations will be placed.
+
+# Set Java Home and ignite optimized JVM settings (or equivalent/preferred JDK and JVM options)
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export JVM_OPTS="-Dfile.encoding=UTF-8 -server -Xms4g -Xmx4g -XX:+UseG1GC -XX:+DisableExplicitGC -Djava.net.preferIPv4Stack=true -XX:MaxMetaspaceSize=1g"
+
+# Set environment variables and PATHs for Go binaries and for Go projects
+export GOPATH=$HOME/dev/go           # GOPATH designates the folder in which Go projects will be placed (not the Go language binaries themselves)
+export PATH=$PATH:$GOPATH/bin        # Add to PATH -- the path to Go projects (such as the 'benchmark' project in this case)
+export PATH=$PATH:/usr/local/go/bin  # Add to PATH -- the path to the actual GoLang binaries
+
+# Set ignite HOME and update PATH
+export IGNITE_HOME=${HOME}/dev/ignite  # Set the HOME path to the standard OOTB Ignite installation (not the ignite-etcd installation), currently version 2.10.0.
+export PATH=$PATH:${IGNITE_HOME}/bin   # Add to Path -- the path to the standard OOTB Ignite installation.
+
+# Set ignite-etcd HOME and update PATH
+export IGNITE_ETCD_HOME=${HOME}/dev/igk8s/ignite-etcd/build/install/ignite-etcd  # Set the HOME path to the ignite-etcd installation
+export PATH=$PATH:${IGNITE_ETCD_HOME}/bin                                        # Add to Path -- the path to the ignite-etcd binaries
+export IGNITE_ETCD_CONFIG=${HOME}/dev/igk8s-config  # Set IGNITE_ETCD_CONFIG to folder containing the ignite-etcd configuration files for this project.
+
+# Set Internal (Static) Server IPs needed to perform the benchmark tests.
+# Note that etcd seemed to have problems if the server IPS below were DNS specifications, instead of internal IP numbers.
+# This was not fully validated and may have been caused by other configuration errors at the time of these tests.
+# In theory DNS names such as ig-etcd-1, ig-etcd-2, ig-etcd-n, etc. should work as well.
+export SERVER_1_IP=10.162.0.2   # etcd or ignite server 1 (ignite server can be an OOTB ignite or and ignite-etcd server)
+export SERVER_2_IP=10.162.0.3   # etcd or ignite server 2 (ignite server can be an OOTB ignite or and ignite-etcd server)
+export SERVER_3_IP=10.162.0.11  # etcd or ignite server 3 (ignite server can be an OOTB ignite or and ignite-etcd server)
+export SERVER_4_IP=10.162.0.9   # ignite-etcd shim (or client) server -- used only for ignite-etcd tests, not used for etcd tests.
+export SERVER_5_IP=10.162.0.10  # benchmark server -- executes all the benchmark tests (calling the etcd or ignite servers)
+
+# Set etcd configuration flags (common across all etcd nodes, using reserved etcd environment variables)
+export ETCDCTL_API=3   # This ensures API version 3.X is called (not 2.X) - probably not necessary, but doens't hurt.
+export ETCD_DATA_DIR=${HOME}/dev/etcd/data.etcd  # This places the etcd db on each node under the folder: $HOME/dev/etcd/data.etcd.
+
+# Uncomment the exports below to set these environment variables ONLY when starting up a new etcd cluster for the first time!
+# After the cluster is up and running (in this case, the first three etcd nodes above), comment out these settings (and run source .profile).
+# Documentation recommends to comment out these lines after the initial startup, but claims it doesn't hurt to leave them in.
+# Findings so far were that if you do not comment them out (after startup), problems with subsequent full restarts may occur.
+#export ETCD_INITIAL_CLUSTER="etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380"
+#export ETCD_INITIAL_CLUSTER_STATE=new
+#export ETCD_INITIAL_CLUSTER_TOKEN=INITIALIZE_WITH_TOKEN_1 # ensure that this value is unique each time a new cluster is started from scratch.
+
+# Set etcd endpoints (for benchmark and client apps)
+export ETCD_ENDPOINTS=${SERVER_1_IP}:2379,${SERVER_2_IP}:2379,${SERVER_3_IP}:2379  # Set the server/ports for the benchmark program to use for etcd nodes.
+export IGNITE_ETCD_ENDPOINTS=${SERVER_4_IP}:2379  # Set the server/port(s) for the benchmark program to use for etcd-shim node(s).

--- a/benchmark/linux/home/etcd-bm-write-all.sh
+++ b/benchmark/linux/home/etcd-bm-write-all.sh
@@ -1,0 +1,1 @@
+benchmark --endpoints=$ETCD_ENDPOINTS --conns=100 --clients=1000 put --key-size=8 --sequential-keys --total=100000 --val-size=256

--- a/benchmark/linux/home/ignite-etcd-bm-write-all.sh
+++ b/benchmark/linux/home/ignite-etcd-bm-write-all.sh
@@ -1,0 +1,1 @@
+benchmark --endpoints=$IGNITE_ETCD_ENDPOINTS --conns=100 --clients=1000 put --key-size=8 --sequential-keys --total=100000 --val-size=256

--- a/benchmark/linux/home/start-etcd1.sh
+++ b/benchmark/linux/home/start-etcd1.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Start up etcd node 1
+
+etcd --name etcd1 --initial-advertise-peer-urls http://${SERVER_1_IP}:2380 \
+  --listen-peer-urls http://${SERVER_1_IP}:2380 \
+  --listen-client-urls http://${SERVER_1_IP}:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://${SERVER_1_IP}:2379
+
+# Note that when even you start a new etcd cluster from scratch for the first time, you should also add the following additional
+# parameters to the startup command above (unless they are already provided for as environment variables in the .profile or .bashrc file).
+# Ensure that these parameters are provided (only for initial starts of new clusters from scratch), either here or in your .profile or .bashrc env file.
+# They should then be commented out after the cluster is fully started, so that they do not interfere with subsequent restarts (not from scratch).
+# ALSO NOTE!!! if you do enable these parameters here, the --intial-cluster-token value below "etcd-cluster-1" must be unique/different each time you start the cluster from scratch.
+# --initial-cluster-token etcd-cluster-1 \
+# --initial-cluster etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380 \
+# --initial-cluster-state new

--- a/benchmark/linux/home/start-etcd2.sh
+++ b/benchmark/linux/home/start-etcd2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Start up etcd node 2
+
+etcd --name etcd2 --initial-advertise-peer-urls http://${SERVER_2_IP}:2380 \
+  --listen-peer-urls http://${SERVER_2_IP}:2380 \
+  --listen-client-urls http://${SERVER_2_IP}:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://${SERVER_2_IP}:2379
+
+# Note that when even you start a new etcd cluster from scratch for the first time, you should also add the following additional
+# parameters to the startup command above (unless they are already provided for as environment variables in the .profile or .bashrc file).
+# Ensure that these parameters are provided (only for initial starts of new clusters from scratch), either here or in your .profile or .bashrc env file.
+# They should then be commented out after the cluster is fully started, so that they do not interfere with subsequent restarts (not from scratch).
+# ALSO NOTE!!! if you do enable these parameters here, the --intial-cluster-token value below "etcd-cluster-1" must be unique/different each time you start the cluster from scratch.
+# --initial-cluster-token etcd-cluster-1 \
+# --initial-cluster etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380 \
+# --initial-cluster-state new

--- a/benchmark/linux/home/start-etcd3.sh
+++ b/benchmark/linux/home/start-etcd3.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Start up etcd node 3
+
+etcd --name etcd3 --initial-advertise-peer-urls http://${SERVER_3_IP}:2380 \
+  --listen-peer-urls http://${SERVER_3_IP}:2380 \
+  --listen-client-urls http://${SERVER_3_IP}:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://${SERVER_3_IP}:2379
+
+# Note that when even you start a new etcd cluster from scratch for the first time, you should also add the following additional
+# parameters to the startup command above (unless they are already provided for as environment variables in the .profile or .bashrc file).
+# Ensure that these parameters are provided (only for initial starts of new clusters from scratch), either here or in your .profile or .bashrc env file.
+# They should then be commented out after the cluster is fully started, so that they do not interfere with subsequent restarts (not from scratch).
+# ALSO NOTE!!! if you do enable these parameters here, the --intial-cluster-token value below "etcd-cluster-1" must be unique/different each time you start the cluster from scratch.
+# --initial-cluster-token etcd-cluster-1 \
+# --initial-cluster etcd1=http://${SERVER_1_IP}:2380,etcd2=http://${SERVER_2_IP}:2380,etcd3=http://${SERVER_3_IP}:2380 \
+# --initial-cluster-state new

--- a/benchmark/linux/home/start-ignite-etcd-shim.sh
+++ b/benchmark/linux/home/start-ignite-etcd-shim.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Recommended for ignite/gridgain.
+# Set to 10, if persistance is enabled, set to 0
+sudo sysctl -w vm.swappiness=10
+
+# Start an ignite-etcd shim/client node on this server 
+ignite-etcd --ignite-config $IGNITE_ETCD_CONFIG/etcd-shim-node.xml
+

--- a/benchmark/linux/home/start-ignite.sh
+++ b/benchmark/linux/home/start-ignite.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Start an standard ignite server (not an ignite-etcd server) using the config file: $IGNITE_ETCD_CONFIG/ignite-server-node.xml
+
+# Recommended for ignite/gridgain.
+# Set to 10, if persistance is enabled, set to 0
+sudo sysctl -w vm.swappiness=10
+
+# Start a standard ignite server on this server/node 
+ignite.sh $IGNITE_ETCD_CONFIG/ignite-server-node.xml
+


### PR DESCRIPTION
Initial additional configuration files, scripts, and instructions to enable benchmarking standard etcd clusters and ignite-etcd clusters in a multi-node Ubuntu environment.